### PR TITLE
Add support for relational lookups on ObjectsByDateTracker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
-python: 2.7
+python:
+ - "2.7"
+ - "3.4"
 env:
     - TOX_ENV=py27-django19
     - TOX_ENV=py34-django19

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,20 @@ Source code
   http://github.com/pennersr/django-trackstats
 
 
+Use Case
+========
+
+- You need an elegant solution for storing statistics in a generic and structural fashion.
+
+- You need to denormalize the results of various aggregated queries.
+
+- You require access to the stored statistics within your application layer.
+
+So, the focus is purely on storing statistics for use within your application later
+on. Other features, such as charting, reports, OLAP, query builders, slicing &
+dicing, integration with ``Datadog`` and the likes are all beyond scope.
+
+
 Concepts
 ========
 

--- a/trackstats/trackers.py
+++ b/trackstats/trackers.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.db import models
 from django.db import connections
 from django.utils import timezone
+from functools import reduce
 
 from .models import Period, StatisticByDate, StatisticByDateAndObject
 
@@ -37,7 +38,8 @@ class ObjectsByDateTracker(object):
             if first_instance is None:
                 # No data
                 return
-            start_date = getattr(first_instance, self.date_field)
+            start_date = reduce(getattr, self.date_field.split('__'),
+                                first_instance)
         if start_date and isinstance(start_date, datetime):
             if timezone.is_aware(start_date):
                 start_date = timezone.make_naive(start_date).date()


### PR DESCRIPTION
This enables trackstats to support relational lookups on an object when looking for the date field:

```
CountObjectsByDateAndObjectTracker(
        period=PERIOD,
        metric=METRIC,
        object_model=MANY_TO_MANY_MODEL,
        object_field='object_field',
        date_field='related_object__date').track(query)
```